### PR TITLE
Switch to netlify app domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
-# oss-valentines (https://oss.love)
+# oss-valentines (https://oss-valentine.netlify.app/)
 
 <img alt="Screenshot of oss.love" src="https://user-images.githubusercontent.com/5865/155968793-5de2b5d1-e782-4637-9088-977aaf1f78f8.png">
-
 
 ## Overview
 
@@ -14,11 +13,9 @@ This site was built to allow people to express their appreciation of open source
 - [Netlify Graph](https://www.netlify.com/blog/announcing-netlify-graph-a-faster-way-for-teams-to-develop-web-apps-with-apis) for simplified API querying
 - [GitHub oAuth](https://docs.github.com/en/developers/apps/building-oauth-apps/authorizing-oauth-apps) for user authenticaion
 
-
-
 ## Development
 
-The site uses some templating via 11ty. 
+The site uses some templating via 11ty.
 
 ```bash
 # install dependencies
@@ -33,7 +30,6 @@ Access to the database (Supabase) is provided by environment variables. Authoris
 
 Others will need to create their own Suapbase database and add their own environment variables to access it.
 
-
 ## Auth for local development
 
 To test the GitHub oAuth flow on a local development server you can expose your local deve server on a public URL using [Netlify Dev](https://www.netlify.com/products/cli).
@@ -45,16 +41,13 @@ ntl dev --live
 
 This will generate a unique public URL which is valid for the duration of the local server's life. Each time you kill the server and run it again, you'll get a new unique URL.
 
-You can provide this URL to GitHub as the basis for an oAuth application. In production this is oAuth application is maintained under the Netlify account and associated with the https://oss.love domain.
+You can provide this URL to GitHub as the basis for an oAuth application. In production this is oAuth application is maintained under the Netlify account and associated with the ~https://oss.love~ https://oss-valentine.netlify.app domain.
 
 To create your own GitHub oAuth application for local testing visit the [Developer Settings](https://github.com/settings/developers) section of [your profile](https://github.com/settings/profile)
 
 Here you can create a new oAuth Application and provide some details. Providing the public URL of your local dev server will enable you to test the athentication flow and authenticated features of the site.
 
-| Setting | Value |
-| ----- | -------- |
-| **Homepage URL** | `https://oss-valentine-XXXXX.netlify.live/` (provided by `ntl dev --live`) |
-| **Authorization callback URLL** | `https://oss-valentine-XXXXX.netlify.live/auth/callback` |
-
-
-
+| Setting                         | Value                                                                      |
+| ------------------------------- | -------------------------------------------------------------------------- |
+| **Homepage URL**                | `https://oss-valentine-XXXXX.netlify.live/` (provided by `ntl dev --live`) |
+| **Authorization callback URLL** | `https://oss-valentine-XXXXX.netlify.live/auth/callback`                   |

--- a/netlify/functions/partials/card.js
+++ b/netlify/functions/partials/card.js
@@ -1,9 +1,5 @@
 module.exports = (data) => {
-
-
   const sponsorCTA = (data) => {
-
-
     console.log(data);
 
     if (data.recipientCanBeSponsored) {
@@ -16,30 +12,34 @@ module.exports = (data) => {
         <p>Show your support by helping to fund their work.</p>
       </div>
       <a href="https://github.com/sponsors/${data.recipientName}?metadata_campaign=netlifysendosslove2022" class="button blue">Sponsor now</a>
-    </div>`
+    </div>`;
     } else {
       return "";
     }
   };
 
-
-
   return `
   <main class="container">
     <div class="content">
       <section class="cta cta-info">
-        <p class="center"><span><a href="https://github.com/${data.senderName}?metadata_campaign=netlifysendosslove2022">@${data.senderName}</a></span> sent you a card to say “Thank you!”</p>
+        <p class="center"><span><a href="https://github.com/${
+          data.senderName
+        }?metadata_campaign=netlifysendosslove2022">@${
+    data.senderName
+  }</a></span> sent you a card to say “Thank you!”</p>
       </section>
       <section class="cta cta-preview">
         <p class="center">Copy and share this URL with @${data.recipientName}.</p>
         <!-- NOTE: I removed the URL link because it was behaving unexpectedly -->
-        <p class="share-link">https://oss.love/card/${data.path}</p>
+        <p class="share-link">https://oss-valentine.netlify.app/card/${data.path}</p>
         <div class="button-group">
           <div class="copy-util">
             <small class="copy-success"></small>
             <button class="copy-url">Copy</button>
           </div>
-          <a class="button tweet-link" href="https://twitter.com/intent/tweet?text=I can’t keep my feelings a secret... I just have to share this card with the world!&url=https://oss.love/card/${data.path}">Tweet</a>
+          <a class="button tweet-link" href="https://twitter.com/intent/tweet?text=I can’t keep my feelings a secret... I just have to share this card with the world!&url=https://oss-valentine.netlify.app/card/${
+            data.path
+          }">Tweet</a>
         </div>
       </section>
       
@@ -48,11 +48,19 @@ module.exports = (data) => {
         <img src="/img/valentines/${data.cardVariant}" alt="" class="valentine" />
         <div class="recipient-details">
           <img class="user-avatar recipient-user-avatar" src="${data.recipientAvatar}" alt="" />
-          <a href="https://github.com/${data.recipientName}?metadata_campaign=netlifysendosslove2022" class="user-handle recipient-user-handle" target="_blank">${data.recipientName}</a>
+          <a href="https://github.com/${
+            data.recipientName
+          }?metadata_campaign=netlifysendosslove2022" class="user-handle recipient-user-handle" target="_blank">${
+    data.recipientName
+  }</a>
         </div>
         <div class="sender-details">
           <img class="user-avatar logged-in-user-avatar" src="${data.senderAvatar}" alt="" />
-          <a href="https://github.com/${data.senderName}?metadata_campaign=netlifysendosslove2022" class="user-handle logged-in-user-handle" target="_blank">${data.senderName}</a>
+          <a href="https://github.com/${
+            data.senderName
+          }?metadata_campaign=netlifysendosslove2022" class="user-handle logged-in-user-handle" target="_blank">${
+    data.senderName
+  }</a>
         </div>
       </div>
 

--- a/src/site/_includes/layouts/base.11ty.js
+++ b/src/site/_includes/layouts/base.11ty.js
@@ -1,22 +1,20 @@
 exports.data = {
   title: "Open source, open hearts",
   bannerTitle: "Share the love",
-  scripts: []
+  scripts: [],
 };
-
-
 
 const ogURL = (path) => {
   if (path) {
-    return `https://oss.love/og/${path}`;
+    return `https://oss-valentine.netlify.app/og/${path}`;
   } else {
-    return `https://oss.love/img/oss-og.png`
+    return `https://oss-valentine.netlify.app/img/oss-og.png`;
   }
 };
 
 const getYear = () => {
-  return new Date().getFullYear()
-}
+  return new Date().getFullYear();
+};
 
 exports.render = function (data) {
   return `
@@ -36,8 +34,8 @@ exports.render = function (data) {
   <meta content="@Netlify" name="twitter:creator">
   <meta content="Open source, Open hearts" name="twitter:title" property="og:title">
   <meta content="Show your love for the OSS community and send a token of appreciation to your favorite open source developers and projects." name="twitter:description" property="og:description">
-  <meta content="https://oss.love" property="og:url">
-  <meta content="https://oss.love" property="twitter:url">
+  <meta content="https://oss-valentine.netlify.app" property="og:url">
+  <meta content="https://oss-valentine.netlify.app" property="twitter:url">
   <meta content="${ogURL(data.ogPath)}" property="og:image">
   <meta content="${ogURL(data.ogPath)}" name="twitter:image">
   <link rel="stylesheet" href="/styles.css">  
@@ -102,7 +100,7 @@ exports.render = function (data) {
   </footer>
 
   <script src="/js/focus-visible.min.js"></script>
-  ${data.scripts.map(s => '<script src="/js/' + s + '"></script>').join("")}
+  ${data.scripts.map((s) => '<script src="/js/' + s + '"></script>').join("")}
 </body>
 
 </html>`;


### PR DESCRIPTION
Switches from oss.love to netlify app domain. It may be best to archive this repo at this point, but if we can keep it working on the app domain, that would be awesome!

In order for GitHub auth to work, the owner of this repo will need to set the `auth/callback` url to `https://oss-valentine.netlify.app/auth/callback`